### PR TITLE
Android SDK 33 Permission Handling

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,8 +57,8 @@
         <uses-feature android:name="android.hardware.camera"/>
 
         <uses-permission android:name="android.permission.CAMERA" />
-        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+        <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
       </config-file>
 
       <config-file parent="/manifest/application" target="AndroidManifest.xml">

--- a/src/android/CanvasCamera.java
+++ b/src/android/CanvasCamera.java
@@ -412,8 +412,9 @@ public class CanvasCamera extends CordovaPlugin implements CanvasCameraInterface
         mCurrentCallbackContext = callbackContext;
 
         if (PermissionHelper.hasPermission(this, Manifest.permission.CAMERA) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                ((PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
+                android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU)) {
             if ("startCapture".equals(action)) {
                 if (LOGGING) Log.i(TAG, "Starting async startCapture thread...");
                 mActivity.runOnUiThread(new Runnable() {

--- a/src/android/CanvasCamera.java
+++ b/src/android/CanvasCamera.java
@@ -63,7 +63,7 @@ public class CanvasCamera extends CordovaPlugin implements CanvasCameraInterface
     private static final int SEC_CAMERA_POSITION = 3;
 
     private final static String[] FILENAMES = {"fullsize", "thumbnail"};
-    private final static String[] PERMISSIONS = {Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
+    private final static String[] PERMISSIONS =  (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) ? new String[] {Manifest.permission.CAMERA} : new String[] {Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
 
     protected int mFps;
     protected int mWidth;


### PR DESCRIPTION
Added support for Android 13 SDK 33.

Specifically SDK 33 always returns false for `PermissionHelper.hasPermission()` on read/write external storage when the app is built for Android target SDK 33.