### PR TITLE
[CORE-843] Fixing xcode15

### DIFF
--- a/www/CanvasCamera.js
+++ b/www/CanvasCamera.js
@@ -291,12 +291,13 @@ CanvasCamera.prototype.createRenderer = (function(element, canvasCamera) {
               case 'file':
                 // If we are using cordova-plugin-ionic-webview plugin which
                 // replaces the default UIWebView with WKWebView.
-                if (window.Ionic &&
-                    window.Ionic.WebView &&
-                    window.Ionic.WebView.convertFileSrc) {
+                var convertFilePath = window.WkWebView && window.WkWebView.convertFilePath;
+                var convertFileSrc = window.Ionic && window.Ionic.WebView && window.Ionic.WebView.convertFileSrc;
+                var convertFileFunction = convertFilePath || convertFileFunction;
+                if (convertFileFunction) {
                   data[
                       this.canvasCamera.options.use
-                  ] = window.Ionic.WebView.convertFileSrc(data[
+                  ] = convertFileFunction(data[
                       this.canvasCamera.options.use
                   ]);
                 }

--- a/www/CanvasCamera.js
+++ b/www/CanvasCamera.js
@@ -293,7 +293,7 @@ CanvasCamera.prototype.createRenderer = (function(element, canvasCamera) {
                 // replaces the default UIWebView with WKWebView.
                 var convertFilePath = window.WkWebView && window.WkWebView.convertFilePath;
                 var convertFileSrc = window.Ionic && window.Ionic.WebView && window.Ionic.WebView.convertFileSrc;
-                var convertFileFunction = convertFilePath || convertFileFunction;
+                var convertFileFunction = convertFilePath || convertFileSrc;
                 if (convertFileFunction) {
                   data[
                       this.canvasCamera.options.use


### PR DESCRIPTION

https://signinsolutions.atlassian.net/browse/CORE-843

By updating to XCode 15, some API's became deprecated or no longer work the way it supposed to. 
One of them is the [UIDevice currentDevice].orientation
When the app is initiated, this API cannot detect the orientation. Because of that, the canvas camera doesn't initiated properly and flips the image to fit the default orientation.
I changed to use the most current API's.
The problem is that the new API's should only run in the main thread.
That is why the code is enclosed with dispatch_sync(dispatch_get_main_queue()